### PR TITLE
Update TodosService.cs

### DIFF
--- a/16 - Fetch/c. WebApi/wasm/client/Todos/TodosService.cs
+++ b/16 - Fetch/c. WebApi/wasm/client/Todos/TodosService.cs
@@ -55,13 +55,13 @@ namespace Fetch_WebApi_Client
 
         public Task<bool> DeleteAsync(Todo value)
         {
-            Task<HttpResponseMessage> result = http.DeleteAsync(new Uri(baseAddress, value.Id.ToString()));
+            Task<HttpResponseMessage> result = http.DeleteAsync(value.Id.ToString());
             return result.ContinueWith<bool>(response => response.Result.IsSuccessStatusCode);
         }
 
         public Task<bool> UpdateAsync(Todo value)
         {
-            Task<HttpResponseMessage> result = http.PutAsJsonAsync(new Uri(baseAddress, value.Id.ToString()), value);
+            Task<HttpResponseMessage> result = http.PutAsJsonAsync(value.Id.ToString(), value);
             return result.ContinueWith<bool>(response => response.Result.IsSuccessStatusCode);
         }
     }


### PR DESCRIPTION
Believe it's not necessary to depend on the base-address after it's been set for the first time. Ideally one sets it on the http-client init, then best left be. Should end with a trailing slash - ref. https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working, 'solved' comment.